### PR TITLE
feature/1.1-observe-trees3d

### DIFF
--- a/src/main/java/src/courseproject207/VisualizationApplication.java
+++ b/src/main/java/src/courseproject207/VisualizationApplication.java
@@ -66,6 +66,8 @@ public class VisualizationApplication extends Application {
             switch (event.getCode()) {
                 case ESCAPE -> camera.setOrientation(0,0,0,0,0);
                 case ALT -> System.out.println(camera.printOrientation());
+                case BACK_SLASH -> camera.setOrientation(10000, 0, -50000, -80 , -100);
+                case INSERT -> world3D.sampleRender();
             }
         });
 
@@ -82,7 +84,6 @@ public class VisualizationApplication extends Application {
 
         public MovableCamera()
         {
-            this.setFarClip(100);
             this.getTransforms().addAll(plane, yRotation, xRotation);
         }
 
@@ -125,7 +126,7 @@ public class VisualizationApplication extends Application {
          */
         public String printOrientation()
         {
-            return plane.getX() + ", " + plane.getY() + ", " + plane.getZ() + ", "
+            return plane.getX() + ", " + plane.getZ() + ", " + plane.getY() + ", "
                     + xRotation.getAngle() + ", " + yRotation.getAngle();
         }
     }

--- a/src/main/java/src/courseproject207/World3d.java
+++ b/src/main/java/src/courseproject207/World3d.java
@@ -8,30 +8,25 @@ import javafx.scene.paint.Color;
 import javafx.scene.paint.PhongMaterial;
 import javafx.scene.shape.Box;
 import src.courseproject207.tree.Tree;
-import src.courseproject207.tree3d.CommonTree3d;
-import src.courseproject207.tree3d.EvergreenTree3d;
-import src.courseproject207.tree3d.MapleTree3d;
-import src.courseproject207.tree3d.Tree3d;
+import src.courseproject207.tree3d.*;
 
 public class World3d extends Group {
-
+    private static final PhongMaterial grassMaterial = new PhongMaterial(Color.valueOf("#9adf8f"));
     private Forest forest;
 
     // X, Y denote the center (0,0) of the view
     public World3d(int x, int y) {
 
         //Setup Ground
-        Box ground = new Box(100000, 1000, 100000);
+        Box ground = new Box(150000, 1000, 150000);
         ground.translateXProperty().set(x);
         ground.translateYProperty().set(y+800);
-        PhongMaterial groundMaterial = new PhongMaterial();
-        groundMaterial.setDiffuseColor(Color.valueOf("#9adf8f"));
-        ground.setMaterial(groundMaterial);
+        ground.setMaterial(grassMaterial);
         this.getChildren().add(ground);
 
         this.forest = new Forest();
 
-        for(int i = 0; i < 100; i++)
+        for(int i = 0; i < 2000; i++)
         {
             Tree t = this.forest.getTrees().get(i);
             Tree3d tree3D = tree3dRender(forest.getRenderMapping().get(t.getFamily()), t.getX(), t.getY(), y, t.getHeight());
@@ -52,11 +47,42 @@ public class World3d extends Group {
         {
             forestDescription = forestDescription.concat("\n" +species + ", number of Trees:" + this.forest.getTreeSpecies().get(species).size());
         }
-        //System.out.println(forestDescription);
+        System.out.println(forestDescription);
         this.setAccessibleHelp("Forest containing 3d Tree Renders");
         this.setAccessibleText(forestDescription);
     }
 
+    /**
+     * Render in a model of each type of 3d tree, for development
+     */
+    public void sampleRender()
+    {
+        this.getChildren().remove(0, this.getChildren().size());
+        Tree3d maple = tree3dRender("Maple", 0.5, 43.4396719038, 400, 15);
+        this.getChildren().addAll(maple.getComponents());
+
+        Tree3d common = tree3dRender("Common", 0.5005, 43.4396719038, 400, 10);
+        this.getChildren().addAll(common.getComponents());
+
+        Tree3d fruit = tree3dRender("Fruit", 0.501, 43.4396719038, 400, 10);
+        this.getChildren().addAll(fruit.getComponents());
+
+        Tree3d north = tree3dRender("NorthAmerican", 0.5015, 43.4396719038, 400, 12);
+        this.getChildren().addAll(north.getComponents());
+
+        Tree3d evergreen = tree3dRender("Evergreen", 0.502, 43.4396719038, 400, 12);
+        this.getChildren().addAll(evergreen.getComponents());
+    }
+
+    /**
+     * Render a tree 3d model given details of a tree
+     * @param render the type of 3d tree
+     * @param x real world longitude
+     * @param z real world latitude
+     * @param y scene height
+     * @param height The height of the tree
+     * @return a tree 3d model
+     */
     public Tree3d tree3dRender(String render, double x,double z, int y,  int height)
     {
         int worldX = (int) Math.ceil((x-0.5)*600000);
@@ -64,13 +90,19 @@ public class World3d extends Group {
 
         switch (render) {
             case "Maple" -> {
-                return new MapleTree3d(worldX,y,worldZ, 50, height*100, 50);
+                return new MapleTree3d(worldX,y,worldZ, height*50);
             }
             case "Evergreen" -> {
-                return new EvergreenTree3d(worldX,y,worldZ, 50, height*100, 50);
+                return new EvergreenTree3d(worldX,y,worldZ, height*50);
+            }
+            case "Fruit" -> {
+                return new FruitTree3d(worldX,y,worldZ, height*50);
+            }
+            case "NorthAmerican" -> {
+                return new NorthAmericanTree3d(worldX,y,worldZ, height*50);
             }
             default -> {
-                return new CommonTree3d(worldX,y,worldZ, 50, height*100, 50);
+                return new CommonTree3d(worldX,y,worldZ, height*50);
             }
         }
     }

--- a/src/main/java/src/courseproject207/tree3d/CommonTree3d.java
+++ b/src/main/java/src/courseproject207/tree3d/CommonTree3d.java
@@ -9,38 +9,27 @@ import src.courseproject207.VisualizationApplication;
 import java.util.Objects;
 
 public class CommonTree3d extends Tree3d {
-
+    private static final PhongMaterial commonLeafMaterial = new PhongMaterial(Color.valueOf("#228B22")
+            , new Image(Objects.requireNonNull(VisualizationApplication.class.getResourceAsStream("leaves.png"))),null,null,null);
     private Box[] components;
 
     public CommonTree3d(){}
 
-    public CommonTree3d(int x,int y, int z, int width,int height, int length){
-        this.components = new Box[7];
+    public CommonTree3d(int x,int y, int z, int height){
+        this.components = new Box[2];
         // Create trunk
-        this.components[0] = new Box(width, height, length);
-        PhongMaterial trunkMaterial = new PhongMaterial();
-        trunkMaterial.setDiffuseColor(Color.valueOf("#725C42"));
-
+        this.components[0] = new Box(40, height, 40);
         this.components[0].setMaterial(trunkMaterial);
         this.components[0].translateXProperty().set(x);
         this.components[0].translateYProperty().set(y);
         this.components[0].translateZProperty().set(z);
 
-        PhongMaterial leafMaterial = new PhongMaterial();
-
-        leafMaterial.setDiffuseColor(Color.valueOf("#228B22"));
-
-        // Set the Image of the leaves
-        leafMaterial.setDiffuseMap(new Image(Objects.requireNonNull(VisualizationApplication.class.getResourceAsStream("leaves.png"))));
-
-        for (int i = 1; i < 7; i++)
-        {
-            this.components[i] = new Box(120, 120, 120);
-            this.components[i].setMaterial(leafMaterial);
-            this.components[i].translateXProperty().set(x);
-            this.components[i].translateZProperty().set(z);
-            this.components[i].translateYProperty().set(this.components[0].getTranslateY()-this.components[0].getHeight()/2);
-        }
+        // Leaves
+        this.components[1] = new Box(120, 120, 120);
+        this.components[1].setMaterial(commonLeafMaterial);
+        this.components[1].translateXProperty().set(x);
+        this.components[1].translateZProperty().set(z);
+        this.components[1].translateYProperty().set(this.components[0].getTranslateY()-this.components[0].getHeight()/2);
     }
 
     @Override

--- a/src/main/java/src/courseproject207/tree3d/EvergreenTree3d.java
+++ b/src/main/java/src/courseproject207/tree3d/EvergreenTree3d.java
@@ -11,44 +11,35 @@ import java.util.Objects;
 
 public class EvergreenTree3d extends Tree3d{
 
+    private static final PhongMaterial evergreenLeafMaterial = new PhongMaterial(Color.valueOf("#0f2e07")
+            , new Image(Objects.requireNonNull(VisualizationApplication.class.getResourceAsStream("leavesgrey.png"))),null,null,null);
     private Box[] components;
     public EvergreenTree3d(){}
 
-    public EvergreenTree3d(int x,int y, int z, int width,int height, int length) {
-        this.components = new Box[7];
+    public EvergreenTree3d(int x,int y, int z, int height) {
+        this.components = new Box[4];
         // Create trunk
-        this.components[0] = new Box(width/2, height, length/2);
-        PhongMaterial trunkMaterial = new PhongMaterial();
-        trunkMaterial.setDiffuseColor(Color.valueOf("#725C42"));
-
+        this.components[0] = new Box(30, height, 30);
         this.components[0].setMaterial(trunkMaterial);
         this.components[0].translateXProperty().set(x);
         this.components[0].translateYProperty().set(y);
         this.components[0].translateZProperty().set(z);
 
-        // Leaf Material
-        PhongMaterial leafMaterial = new PhongMaterial();
-        leafMaterial.setDiffuseMap(new Image(Objects.requireNonNull(VisualizationApplication.class.getResourceAsStream("leavesgrey.png"))));
-        leafMaterial.setDiffuseColor(Color.valueOf("#145c14"));
-
-        double leafWidth = height/6;
-        double bottomTree = y+height/2-height/6;
-        double leafHeight = this.components[0].getHeight()/3;
-        double leafDepth = height/2;
-        //need ratio to determine if leaf clips into trunk
-        double ratio = java.lang.Math.max(width,length);
-        if (height/ratio>0.1) {
-            leafWidth = height/3;
-            leafDepth = height;
-        }
-        // Create leaves
-
-        this.components[1]=this.makeBox(x,bottomTree-leafWidth ,z,leafWidth,leafHeight,leafDepth, leafMaterial);
-        this.components[2]=this.makeBox(x+leafWidth, bottomTree-leafWidth,z,leafWidth,leafHeight,leafDepth, leafMaterial);
-        this.components[3]=this.makeBox(x-leafWidth, bottomTree-leafWidth,z,leafWidth,leafHeight,leafDepth, leafMaterial);
-        this.components[4]=this.makeBox(x+(leafWidth/2), (bottomTree-leafWidth)-leafHeight,z,leafWidth,leafHeight,leafDepth*3/4, leafMaterial);
-        this.components[5]=this.makeBox(x-(leafWidth/2), (bottomTree-leafWidth)-leafHeight,z,leafWidth,leafHeight,leafDepth*3/4, leafMaterial);
-        this.components[6]=this.makeBox(x, (bottomTree-(leafWidth))-2*leafHeight,z,leafWidth,leafHeight,leafDepth/3, leafMaterial);
+        this.components[1] = new Box(150, 150, 150);
+        this.components[1].setMaterial(evergreenLeafMaterial);
+        this.components[1].translateXProperty().set(x);
+        this.components[1].translateZProperty().set(z);
+        this.components[1].translateYProperty().set(this.components[0].getTranslateY()-this.components[0].getHeight()/2);
+        this.components[2] = new Box(100, 100, 100);
+        this.components[2].setMaterial(evergreenLeafMaterial);
+        this.components[2].translateXProperty().set(x);
+        this.components[2].translateZProperty().set(z);
+        this.components[2].translateYProperty().set(this.components[0].getTranslateY()-this.components[0].getHeight()/2-50);
+        this.components[3] = new Box(50, 50, 50);
+        this.components[3].setMaterial(evergreenLeafMaterial);
+        this.components[3].translateXProperty().set(x);
+        this.components[3].translateZProperty().set(z);
+        this.components[3].translateYProperty().set(this.components[0].getTranslateY()-this.components[0].getHeight()/2-120);
     }
     @Override
     public Node[] getComponents() {

--- a/src/main/java/src/courseproject207/tree3d/FruitTree3d.java
+++ b/src/main/java/src/courseproject207/tree3d/FruitTree3d.java
@@ -10,33 +10,36 @@ import javafx.scene.shape.Box;
 import java.util.Objects;
 
 public class FruitTree3d extends Tree3d{
+    private static final PhongMaterial fruitLeafMaterial = new PhongMaterial(Color.valueOf("#145c14")
+            , new Image(Objects.requireNonNull(VisualizationApplication.class.getResourceAsStream("leavesgrey.png"))),null,null,null);
+    private static final PhongMaterial fruitMaterial = new PhongMaterial(Color.valueOf("#ffe135"));
     private Box[] components;
     public FruitTree3d(){}
-    public FruitTree3d(int x,int y, int z, int width,int height, int length) {
-        this.components = new Box[6];
+    public FruitTree3d(int x,int y, int z,int height) {
+        this.components = new Box[4];
         // Create trunk
-        this.components[0] = new Box(width/2, height, length/2);
-        PhongMaterial trunkMaterial = new PhongMaterial();
-        trunkMaterial.setDiffuseColor(Color.valueOf("#725C42"));
-
+        this.components[0] = new Box(25, height, 25);
         this.components[0].setMaterial(trunkMaterial);
         this.components[0].translateXProperty().set(x);
         this.components[0].translateYProperty().set(y);
         this.components[0].translateZProperty().set(z);
 
-        // Leaf material
-        PhongMaterial leafMaterial = new PhongMaterial();
-        leafMaterial.setDiffuseMap(new Image(Objects.requireNonNull(VisualizationApplication.class.getResourceAsStream("leavesgrey.png"))));
-        leafMaterial.setDiffuseColor(Color.valueOf("#145c14"));
-
-        double leafWidth = height/4;
-        double leafHeight = this.components[0].getHeight()/3;
-        double leafDepth = this.components[0].getHeight()/2;
-        this.components[1]=this.makeBox(x, (this.components[0].getTranslateY()-(this.components[0].getHeight()*1/5)),z,leafWidth,leafHeight,leafDepth, leafMaterial);
-        this.components[2]=this.makeBox(x+leafWidth, (this.components[0].getTranslateY()-(this.components[0].getHeight()*1/5)),z,leafWidth,leafHeight,leafDepth, leafMaterial);
-        this.components[3]=this.makeBox(x-leafWidth, (this.components[0].getTranslateY()-(this.components[0].getHeight()*1/5)),z,leafWidth,leafHeight,leafDepth, leafMaterial);
-        this.components[4]=this.makeBox(x+(leafWidth/2), (this.components[0].getTranslateY()-(this.components[0].getHeight()*1/5))-leafHeight,z,leafWidth,leafHeight,leafDepth/2, leafMaterial);
-        this.components[5]=this.makeBox(x-(leafWidth/2), (this.components[0].getTranslateY()-(this.components[0].getHeight()*1/5))-leafHeight,z,leafWidth,leafHeight,leafDepth/2, leafMaterial);
+        // Leaves
+        this.components[1] = new Box(120, 120, 120);
+        this.components[1].setMaterial(fruitLeafMaterial);
+        this.components[1].translateXProperty().set(x);
+        this.components[1].translateZProperty().set(z);
+        this.components[1].translateYProperty().set(this.components[0].getTranslateY()-this.components[0].getHeight()/2);
+        this.components[2] = new Box(20,20,20);
+        this.components[2].setMaterial(fruitMaterial);
+        this.components[2].translateXProperty().set(x-60);
+        this.components[2].translateZProperty().set(z-60);
+        this.components[2].translateYProperty().set(this.components[0].getTranslateY()-this.components[0].getHeight()/2-20);
+        this.components[3] = new Box(20,20,20);
+        this.components[3].setMaterial(fruitMaterial);
+        this.components[3].translateXProperty().set(x+60);
+        this.components[3].translateZProperty().set(z+60);
+        this.components[3].translateYProperty().set(this.components[0].getTranslateY()-this.components[0].getHeight()/2);
     }
     @Override
     public Node[] getComponents() {

--- a/src/main/java/src/courseproject207/tree3d/MapleTree3d.java
+++ b/src/main/java/src/courseproject207/tree3d/MapleTree3d.java
@@ -11,22 +11,26 @@ import java.util.Objects;
 public class MapleTree3d extends Tree3d{
     private Box[] components;
     public MapleTree3d(){}
-    public MapleTree3d(int x,int y, int z, int width,int height, int length) {
+    public MapleTree3d(int x,int y, int z,int height) {
         this.components = new Box[2];
         // Create trunk
-        this.components[0] = new Box(width, height, length);
+        this.components[0] = new Box(30, height, 30);
         PhongMaterial trunkMaterial = new PhongMaterial();
         trunkMaterial.setDiffuseColor(Color.valueOf("#725C42"));
-
         this.components[0].setMaterial(trunkMaterial);
         this.components[0].translateXProperty().set(x);
         this.components[0].translateYProperty().set(y);
         this.components[0].translateZProperty().set(z);
+
         // Leaf material
         PhongMaterial leafMaterial = new PhongMaterial();
         leafMaterial.setDiffuseMap(new Image(Objects.requireNonNull(VisualizationApplication.class.getResourceAsStream("leavesgrey.png"))));
-        leafMaterial.setDiffuseColor(Color.valueOf("#d1721f"));
-        this.components[1]=this.makeBox(x,y-height/4,z,height/2,height,height/2,leafMaterial);
+        leafMaterial.setDiffuseColor(Color.valueOf("#bf0505"));
+        this.components[1]= new Box(160, 160, 160);
+        this.components[1].setMaterial(leafMaterial);
+        this.components[1].translateXProperty().set(x);
+        this.components[1].translateZProperty().set(z);
+        this.components[1].translateYProperty().set(this.components[0].getTranslateY()-this.components[0].getHeight()/2);
 
 }
     @Override

--- a/src/main/java/src/courseproject207/tree3d/NorthAmericanTree3d.java
+++ b/src/main/java/src/courseproject207/tree3d/NorthAmericanTree3d.java
@@ -10,26 +10,31 @@ import javafx.scene.shape.Box;
 import java.util.Objects;
 
 public class NorthAmericanTree3d extends Tree3d{
+    private static final PhongMaterial northLeafMaterial = new PhongMaterial(Color.valueOf("#235416")
+            , new Image(Objects.requireNonNull(VisualizationApplication.class.getResourceAsStream("leavesgrey.png"))),null,null,null);
     private Box[] components;
     public NorthAmericanTree3d(){}
-    public NorthAmericanTree3d(int x,int y, int z, int width,int height, int length) {
-        this.components = new Box[2];
+    public NorthAmericanTree3d(int x,int y, int z, int height) {
+        this.components = new Box[3];
         // Create trunk
-        this.components[0] = new Box(width, height, length);
-        PhongMaterial trunkMaterial = new PhongMaterial();
-        trunkMaterial.setDiffuseColor(Color.valueOf("#725C42"));
+        this.components[0] = new Box(30, height, 30);
 
         this.components[0].setMaterial(trunkMaterial);
         this.components[0].translateXProperty().set(x);
         this.components[0].translateYProperty().set(y);
         this.components[0].translateZProperty().set(z);
 
-        // Leaf material
-        PhongMaterial leafMaterial = new PhongMaterial();
-        leafMaterial.setDiffuseMap(new Image(Objects.requireNonNull(VisualizationApplication.class.getResourceAsStream("leavesgrey.png"))));
-        leafMaterial.setDiffuseColor(Color.valueOf("#1d590e"));
-        this.components[1]= this.makeBox(x,y-height/4,z,height/2,height,height/2,leafMaterial);
-
+        // Leaves
+        this.components[1] = new Box(120, 120, 120);
+        this.components[1].setMaterial(northLeafMaterial);
+        this.components[1].translateXProperty().set(x);
+        this.components[1].translateZProperty().set(z);
+        this.components[1].translateYProperty().set(this.components[0].getTranslateY()-this.components[0].getHeight()/2);
+        this.components[2] = new Box(120, 120, 120);
+        this.components[2].setMaterial(northLeafMaterial);
+        this.components[2].translateXProperty().set(x);
+        this.components[2].translateZProperty().set(z);
+        this.components[2].translateYProperty().set(this.components[0].getTranslateY()-this.components[0].getHeight()/2-100);
     }
     @Override
     public Node[] getComponents() {

--- a/src/main/java/src/courseproject207/tree3d/Tree3d.java
+++ b/src/main/java/src/courseproject207/tree3d/Tree3d.java
@@ -1,10 +1,12 @@
 package src.courseproject207.tree3d;
 
 import javafx.scene.Node;
+import javafx.scene.paint.Color;
 import javafx.scene.paint.PhongMaterial;
-import javafx.scene.shape.Box;
 
 public abstract class Tree3d {
+
+    public static final PhongMaterial trunkMaterial = new PhongMaterial(Color.valueOf("#725C42"));
 
     /**
      * @return an Array of 3d nodes representing a 3d Tree
@@ -15,24 +17,4 @@ public abstract class Tree3d {
      * @return a clone of a 3D Tree Object
      */
     public abstract Tree3d clone();
-
-    /**
-     * Generate a box with given dimensions and material
-     * @param x position
-     * @param y position
-     * @param z position
-     * @param width size
-     * @param height size
-     * @param length size
-     * @param material texture
-     * @return Box with the given features
-     */
-    Box makeBox(double x, double y, double z, double width, double height, double length, PhongMaterial material){
-        Box B = new Box(width, height, length);
-        B.setMaterial(material);
-        B.translateXProperty().set(x);
-        B.translateZProperty().set(z);
-        B.translateYProperty().set(y);
-        return B;
-    }
 }


### PR DESCRIPTION
Trees can now be rendered with their corresponding 3d models by converting between real-world longitude, latitude, and scene x, and y.
To get a better observation of the forest a user can use the escape key to get a top-down view to see patterns.
To get a better observation of the tree to render types a user can click backslash ("\") helpful for future artistic development.
Optimizations to the tree render types use static instances of materials to speed up file load and render time. This reduces the redundancy of loading the same material for multiple instances of the same type of render.
The escape key can still be used to recenter the camera.
Fixed camera orientation print state.